### PR TITLE
[express] honor X-Forwarded-* headers by default

### DIFF
--- a/express.js
+++ b/express.js
@@ -5,7 +5,8 @@ var express = extensions.express = assign({}, extensions.express);
 
 express.baseUrl = function expressBaseUrl(req) {
     var host = req.get('x-forwarded-host') || req.get('host');
-    return `${req.protocol}://${host}${req.baseUrl}`;
+    var protocol = req.get('x-forwarded-proto') || req.protocol;
+    return `${protocol}://${host}${req.baseUrl}`;
 };
 
 express.requested = function expressRequested(req) {


### PR DESCRIPTION
Protocol is only set to X-Forwarded-Proto when `trust proxy` is set
in the express configuration. We want to always use this header