### PR TITLE
[url] fix copying of arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ extensions.qs = require('qs');
 
 function merge(base /*, updates... */) {
     var args = [], args_i = arguments.length;
-    while (args_i-- > 1) args[args_i] = arguments[args_i];
+    while (args_i-- > 1) args[args_i - 1] = arguments[args_i];
 
     args.unshift(base);
     args.push(function(base, update) {
@@ -99,7 +99,7 @@ function concatPaths() {
  */
 function pathEscape(strings/* , ...args */) {
     var args = [], args_i = arguments.length;
-    while (args_i-- > 1) args[args_i] = arguments[args_i];
+    while (args_i-- > 1) args[args_i - 1] = arguments[args_i];
 
     var out = [];
     var len = strings.length;

--- a/test/url.js
+++ b/test/url.js
@@ -37,6 +37,14 @@ describe('URL', function() {
             assert.equal(result, expected);
         })
 
+        it('should escape path templates with more than one variable', () => {
+            const foo = 'foo';
+            const baz = 'baz';
+            const result = ext.path.escape`/${foo}/bar/${baz}`;
+
+            assert.equal(result, '/foo/bar/baz');
+        })
+
     })
 
 });


### PR DESCRIPTION
Current implementation caused one "undefined" element at the start of each args array, which was no issue for the merge function but broke pathEscape.